### PR TITLE
ArduinoMIDIVS10xxSynth sketch: add support for Arduino Mega 2560. It has other hardware SPI bus pins mapping.

### DIFF
--- a/src/SDEMP/ArduinoMIDIVS10xxSynth/ArduinoMIDIVS10xxSynth.ino
+++ b/src/SDEMP/ArduinoMIDIVS10xxSynth/ArduinoMIDIVS10xxSynth.ino
@@ -98,18 +98,32 @@ uint16_t MIDI_CHANNEL_FILTER = 0b1111111111111111;
 #define VS_RESET  8 // Reset is active low
 #endif
 #ifdef VS1003_MODULE
+#if !defined(ARDUINO_AVR_MEGA2560)
 // VS1003 Module pin definitions
 #define VS_XCS    8 // Control Chip Select Pin (for accessing SPI Control/Status registers)
 #define VS_XDCS   9 // Data Chip Select / BSYNC Pin
 #define VS_DREQ   7 // Data Request Pin: Player asks for more data
 #define VS_RESET  10 // Reset is active low
+#else
+#define VS_XCS    49
+#define VS_XDCS   47
+#define VS_DREQ   48
+#define VS_RESET  53
+#endif /* ARDUINO_AVR_MEGA2560 */
 #endif
 // VS10xx SPI pin connections (both boards)
 // Provided here for info only - not used in the sketch as the SPI library handles this
+#if !defined(ARDUINO_AVR_MEGA2560)
 #define VS_MOSI   11
 #define VS_MISO   12
 #define VS_SCK    13
 #define VS_SS     10
+#else
+#define VS_MOSI   51
+#define VS_MISO   50
+#define VS_SCK    52
+#define VS_SS     53
+#endif /* ARDUINO_AVR_MEGA2560 */
 
 // Optional - use Digital IO as the power pins
 //#define VS_VCC    6


### PR DESCRIPTION
Thank you so much for your great research on how to bring up MIDI on VS1003 in SPI mode!

I propose a minor update to make the sketch applicable for Arduino Mega as well. I've made a remap of the VS1003 control signals to relocate them closer to the actual h/w SPI bus pins (50, 51, 52, 53) of the Mega board.

![](https://user-images.githubusercontent.com/5849637/174545898-4e31118c-d31d-407b-8fb1-d218b3debb57.jpg)
